### PR TITLE
Remove FR translation of MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,27 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-Licence MIT
-
-(c) Droit d'auteur – ervice numérique canadien, 2019
-
-La présente autorise toute personne d'obtenir gratuitement une copie du présent 
-logiciel et des documents connexes (le « logiciel »), de traiter le logiciel 
-sans restriction, y compris, mais sans s'y limiter, les droits d'utiliser, de 
-copier, de modifier, de fusionner, de publier, de distribuer, d'accorder une 
-sous licence et de vendre des copies dudit logiciel, et de permettre aux 
-personnes auxquelles le logiciel est fourni de le faire, selon les conditions 
-suivantes :
-
-L'avis de droit d'auteur ci dessus et le présent avis de permission seront inclus 
-dans toutes les copies et les sections importantes du logiciel.
-
-LE LOGICIEL EST FOURNI « TEL QUEL », SANS AUCUNE GARANTIE, EXPRESSE OU IMPLICITE, 
-Y COMPRIS, MAIS SANS S'Y LIMITER, LA GARANTIE DE QUALITÉ MARCHANDE, L'ADAPTATION 
-À UN USAGE PARTICULIER ET L'ABSENCE DE CONTREFAÇON. EN AUCUN CAS LES AUTEURS OU 
-LES DÉTENTEURS DU DROIT D'AUTEUR NE SERONT TENUS RESPONSABLES DE TOUTE DEMANDE, 
-DOMMAGE OU BRIS DE CONTRAT, DÉLIT CIVIL OU TOUT AUTRE MANQUEMENT LIÉ AU LOGICIEL,
-À SON UTILISATION OU À D'AUTRES ÉCHANGES LIÉS AU LOGICIEL.


### PR DESCRIPTION
Removing on advice of TBS legal. French translation has not been tried in court, whereas the English has.